### PR TITLE
fix: latest event should appear at the top (#29)

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,7 +8,7 @@ function App() {
   useEffect(() => {
     socket.emit("github-event");
     socket.on("events/github", (data) => {
-      setEvents([...events, data]);
+      setEvents([data, ...events]);
     });
   });
 


### PR DESCRIPTION
## Fixes Issue
Closes #29 

## Changes proposed
[x] - Displaying the latest event at the top

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/EddieHubLive/pull/38"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

