### PR TITLE
fix: multiple image for same user on map 

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,10 +5,20 @@ import React, { useEffect, useState } from "react";
 
 function App() {
   const [events, setEvents] = useState([]);
+  const [uniqueUsers, setUniqueUsers] = useState([]);
   useEffect(() => {
     socket.emit("github-event");
     socket.on("events/github", (data) => {
       setEvents([...events, data]);
+      if (
+        !uniqueUsers.find(
+          (user) => user.githubUsername._id === data.githubUsername._id
+        )
+      ) {
+        setUniqueUsers([...uniqueUsers, data]);
+      }
+      console.log("events: "+events)
+      console.log(uniqueUsers)
     });
   });
 
@@ -20,7 +30,7 @@ function App() {
         ))}
       </div>
       <div className="w-2/3">
-        <Map events={[...new Set(events)]} />
+        <Map events={uniqueUsers} />
       </div>
     </main>
   );

--- a/src/App.js
+++ b/src/App.js
@@ -17,8 +17,6 @@ function App() {
       ) {
         setUniqueUsers([...uniqueUsers, data]);
       }
-      console.log("events: "+events)
-      console.log(uniqueUsers)
     });
   });
 

--- a/src/App.js
+++ b/src/App.js
@@ -20,7 +20,7 @@ function App() {
         ))}
       </div>
       <div className="w-2/3">
-        <Map events={events} />
+      <Map events={[...new Set(events)]} />
       </div>
     </main>
   );

--- a/src/App.js
+++ b/src/App.js
@@ -20,7 +20,7 @@ function App() {
         ))}
       </div>
       <div className="w-2/3">
-      <Map events={[...new Set(events)]} />
+        <Map events={[...new Set(events)]} />
       </div>
     </main>
   );


### PR DESCRIPTION
## Fixes Issue
Close: #31 

## Changes proposed
previously, we converted the list of events to set 
but that dint work as we want to remove duplicates based on the Github profile

Now duplicates are removed based on GitHub id in objects 
so only one entry will be there in uniqueUsers list per user 
that will result in removing dup images from the map




## Screenshots

![image](https://user-images.githubusercontent.com/51873202/178414735-cc6f2629-b984-4937-896a-bbf78803e6ae.png)
as we can see only one pic is there for multiple events of the same user


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/EddieHubLive/pull/40"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

