### PR TITLE
fix: filtering out specific GitHub action events

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,9 +6,14 @@ import React, { useEffect, useState } from "react";
 function App() {
   const [events, setEvents] = useState([]);
   const [uniqueUsers, setUniqueUsers] = useState([]);
+  const ignoreEvents = ["workflowRun", "checkSuite", "checkRun"];
+
   useEffect(() => {
     socket.emit("github-event");
     socket.on("events/github", (data) => {
+      if(ignoreEvents.includes(data.event))
+        return;
+
       setEvents([data, ...events]);
       if (
         !uniqueUsers.find(


### PR DESCRIPTION
## Fixes Issue
Close #30 

## Changes proposed
 This will filter out the GitHub action events for "workflowRun", "checkSuite", and "checkRun".

<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done
[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

## Note to reviewers
In the issue #30 there are three events to hide and one was misspelled which was "checksuite". In my test I see that it should be camal case, "checkSuite". I am pointing it out if you noticed the difference from the write up.