### PR TITLE
About button Stacking on mobile

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -27,7 +27,7 @@ function App() {
     <div className="flex h-screen flex-col">
       <Header />
       <main className="flex grow overflow-hidden">
-        <div className="flex w-1/3 flex-col gap-2 overflow-y-auto p-2 mt-10">
+        <div className="flex w-1/3 flex-col gap-2 overflow-y-auto p-2 mt-8">
           {events.map((event) => (
             <EventCard key={event._id} data={event} />
           ))}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -27,7 +27,7 @@ function App() {
     <div className="flex h-screen flex-col">
       <Header />
       <main className="flex grow overflow-hidden">
-        <div className="flex w-1/3 flex-col gap-2 overflow-y-auto p-2 ">
+        <div className="flex w-1/3 flex-col gap-2 overflow-y-auto p-2 mt-10">
           {events.map((event) => (
             <EventCard key={event._id} data={event} />
           ))}

--- a/src/components/about-modal.jsx
+++ b/src/components/about-modal.jsx
@@ -50,7 +50,7 @@ export default function OpenModal() {
                       <XMarkIcon className="h-6 w-6" aria-hidden="true" />
                     </button>
                   </div>
-                  <div className="sm:flex sm:items-start ">
+                  <div className="sm:flex sm:items-start">
                     <div className="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
                       <Dialog.Title as="h3" className="text-lg font-medium leading-6 text-gray-900">
                         Welcome to EddieHubLive

--- a/src/components/about-modal.jsx
+++ b/src/components/about-modal.jsx
@@ -9,7 +9,7 @@ export default function OpenModal() {
     <>
       <button
         type="button"
-        className="ml-3 inline-flex items-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-gray-500 focus:outline-none focus:ring-gray-500 focus:ring-offset-2"
+        className="ml-3 inline-flex relative items-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-gray-500 focus:outline-none focus:ring-gray-500 focus:ring-offset-2"
         onClick={() => setOpen(true)}
       >
         About
@@ -29,7 +29,7 @@ export default function OpenModal() {
           </Transition.Child>
 
           <div className="fixed inset-0 z-10 overflow-y-auto">
-            <div className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+            <div className="flex min-h-full justify-center p-4 text-center sm:p-0 items-center ">
               <Transition.Child
                 as={Fragment}
                 enter="ease-out duration-300"
@@ -40,17 +40,17 @@ export default function OpenModal() {
                 leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
               >
                 <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-white px-4 pt-5 pb-4 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
-                  <div className="absolute top-0 right-0 hidden pt-4 pr-4 sm:block">
+                  <div className="absolute top-0 right-0 pt-4 pr-4 sm:block">
                     <button
                       type="button"
-                      className="rounded-md bg-white text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-indigo-500 focus:ring-offset-2"
+                      className="sm:block rounded-md bg-white text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-indigo-500 focus:ring-offset-2"
                       onClick={() => setOpen(false)}
                     >
-                      <span className="sr-only">Close</span>
+                      <span className="sr-only" onClick={()=>setOpen(false)}>Close</span>
                       <XMarkIcon className="h-6 w-6" aria-hidden="true" />
                     </button>
                   </div>
-                  <div className="sm:flex sm:items-start">
+                  <div className="sm:flex sm:items-start ">
                     <div className="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
                       <Dialog.Title as="h3" className="text-lg font-medium leading-6 text-gray-900">
                         Welcome to EddieHubLive

--- a/src/components/about-modal.jsx
+++ b/src/components/about-modal.jsx
@@ -46,7 +46,7 @@ export default function OpenModal() {
                       className="sm:block rounded-md bg-white text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-indigo-500 focus:ring-offset-2"
                       onClick={() => setOpen(false)}
                     >
-                      <span className="sr-only" onClick={()=>setOpen(false)}>Close</span>
+                      <span className="sr-only">Close</span>
                       <XMarkIcon className="h-6 w-6" aria-hidden="true" />
                     </button>
                   </div>

--- a/src/components/event-card.jsx
+++ b/src/components/event-card.jsx
@@ -4,8 +4,8 @@ import PropTypes from "prop-types";
 
 function EventCard({ data }) {
   return (
-    <div key={data.event._id} className="flex w-full flex-col rounded-lg border-l-8  border-primary bg-white p-4 shadow-lg">
-      <div className="flex justify-end">{FormatTime(data.updatedAt)}</div>
+    <div key={data.event._id} className="flex w-full flex-col rounded-lg border-l-8 border-primary bg-white p-4 shadow-lg">
+      <div className="flex justify-end ">{FormatTime(data.updatedAt)}</div>
       <div className="flex justify-between font-semibold  xs:flex-col">
         <div className="rounded-full break-all md:break-normal">
           <a rel="noreferrer" target="_blank" href={data.githubUserURL}>

--- a/src/components/event-card.jsx
+++ b/src/components/event-card.jsx
@@ -5,7 +5,7 @@ import PropTypes from "prop-types";
 function EventCard({ data }) {
   return (
     <div key={data.event._id} className="flex w-full flex-col rounded-lg border-l-8 border-primary bg-white p-4 shadow-lg">
-      <div className="flex justify-end ">{FormatTime(data.updatedAt)}</div>
+      <div className="flex justify-end">{FormatTime(data.updatedAt)}</div>
       <div className="flex justify-between font-semibold  xs:flex-col">
         <div className="rounded-full break-all md:break-normal">
           <a rel="noreferrer" target="_blank" href={data.githubUserURL}>

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -5,7 +5,7 @@ export default function Header() {
   return (
     <nav className="bg-gray-800">
       <div className="mx-auto max-w-7xl">
-        <div className="h-16 md:flex md:items-center md:justify-between md:space-x-5">
+        <div className="h-16 flex md:items-center justify-between md:space-x-5">
           <div className="flex items-center space-x-5">
             <div className="flex-shrink-0">
               <div className="relative">
@@ -20,7 +20,7 @@ export default function Header() {
               </p>
             </div>
           </div>
-          <div className="justify-stretch mt-6 flex flex-col-reverse space-y-4 space-y-reverse sm:flex-row-reverse sm:justify-end sm:space-y-0 sm:space-x-3 sm:space-x-reverse md:mt-0 md:flex-row md:space-x-3">
+          <div className="justify-stretch mt-6 xs:my-auto flex flex-col-reverse space-y-4 space-y-reverse sm:flex-row-reverse sm:justify-end sm:space-y-0 sm:space-x-3 sm:space-x-reverse md:mt-0 md:flex-row md:space-x-3">
             <OpenModal />
           </div>
         </div>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,3 +1,5 @@
+const defaultTheme = require("tailwindcss/defaultTheme");
+
 module.exports = {
   content: ["./src/**/*.{js,jsx,ts,tsx}"],
   theme: {
@@ -6,6 +8,10 @@ module.exports = {
         bg: "var(--off-white)",
         primary: "var(--color-primary)",
       },
+    },
+    screens: {
+      xs: { max: "895px" },
+      ...defaultTheme.screens,
     },
     plugins: [],
   },


### PR DESCRIPTION
Closes #102 

## Fixes Issue
#102 

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed

1. Dialogue box is centered and closing the dialogue box bug is resolved which was not possible earlier
![image](https://user-images.githubusercontent.com/90546692/218161128-870f5c73-90ab-43c3-bd09-3d59cee363b9.png)
2. About button was stacked under event cards, its being resolved and given a margin-top to 10px to cards so that button and cards could be distinguished
![image](https://user-images.githubusercontent.com/90546692/218161697-fe4eede7-4421-4932-98ef-50d9f3bd7626.png)

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done
[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots
![image](https://user-images.githubusercontent.com/90546692/218162025-18a08bbc-ec2d-43dc-9a2d-3e56354d1362.png)

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->